### PR TITLE
Feature: hide results

### DIFF
--- a/PollApp.ts
+++ b/PollApp.ts
@@ -39,6 +39,7 @@ export class PollApp extends App implements IUIKitInteractionHandler {
                 config?: {
                     mode?: string,
                     visibility?: string,
+                    showResults?: string,
                 },
             },
         } = data.view as any;

--- a/src/definition.ts
+++ b/src/definition.ts
@@ -17,6 +17,7 @@ export interface IPoll {
     votes: Array<IVoter>;
     finished?: boolean;
     confidential?: boolean;
+    showResults?: boolean;
     singleChoice?: boolean;
 }
 

--- a/src/lib/createPollBlocks.ts
+++ b/src/lib/createPollBlocks.ts
@@ -48,11 +48,9 @@ export function createPollBlocks(block: BlockBuilder, question: string, options:
             return;
         }
 
-
         if (!poll.showResults && !poll.finished) {
             return;
         }
-
 
         const graph = buildVoteGraph(poll.votes[index], poll.totalVotes);
         block.addContextBlock({

--- a/src/lib/createPollBlocks.ts
+++ b/src/lib/createPollBlocks.ts
@@ -48,6 +48,12 @@ export function createPollBlocks(block: BlockBuilder, question: string, options:
             return;
         }
 
+
+        if (!poll.showResults && !poll.finished) {
+            return;
+        }
+
+
         const graph = buildVoteGraph(poll.votes[index], poll.totalVotes);
         block.addContextBlock({
             elements: [

--- a/src/lib/createPollMessage.ts
+++ b/src/lib/createPollMessage.ts
@@ -50,8 +50,8 @@ export async function createPollMessage(data: IUIKitViewSubmitIncomingInteractio
     }
 
     try {
-        const { config = { mode: 'multiple', visibility: 'open' } } = state;
-        const { mode = 'multiple', visibility = 'open' } = config;
+        const { config = { mode: 'multiple', visibility: 'open', showResults: 'always' } } = state;
+        const { mode = 'multiple', visibility = 'open', showResults = 'always' } = config;
 
         const showNames = await read.getEnvironmentReader().getSettings().getById('use-user-name');
 
@@ -74,6 +74,7 @@ export async function createPollMessage(data: IUIKitViewSubmitIncomingInteractio
             votes: options.map(() => ({ quantity: 0, voters: [] })),
             confidential: visibility === 'confidential',
             singleChoice: mode === 'single',
+            showResults: showResults === 'always',
         };
 
         const block = modify.getCreator().getBlockBuilder();

--- a/src/lib/createPollModal.ts
+++ b/src/lib/createPollModal.ts
@@ -87,7 +87,7 @@ export async function createPollModal({ id = '', question, persistence, data, mo
                             value: 'always',
                         },
                         {
-                            text: block.newPlainTextObject('Only when poll is finished'),
+                            text: block.newPlainTextObject('Show result when poll is finished'),
                             value: 'finished',
                         },
                     ],

--- a/src/lib/createPollModal.ts
+++ b/src/lib/createPollModal.ts
@@ -77,6 +77,21 @@ export async function createPollModal({ id = '', question, persistence, data, mo
                         },
                     ],
                 }),
+                block.newStaticSelectElement({
+                    placeholder: block.newPlainTextObject('Always shows results'),
+                    actionId: 'showResults',
+                    initialValue: 'always',
+                    options: [
+                        {
+                            text: block.newPlainTextObject('Always shows results'),
+                            value: 'always',
+                        },
+                        {
+                            text: block.newPlainTextObject('Only when poll is finished'),
+                            value: 'finished',
+                        },
+                    ],
+                }),
             ],
         });
 

--- a/src/lib/createPollModal.ts
+++ b/src/lib/createPollModal.ts
@@ -87,7 +87,7 @@ export async function createPollModal({ id = '', question, persistence, data, mo
                             value: 'always',
                         },
                         {
-                            text: block.newPlainTextObject('Show result when poll is finished'),
+                            text: block.newPlainTextObject('Show results only after finished'),
                             value: 'finished',
                         },
                     ],


### PR DESCRIPTION
# What does this PR do?

I'm adding the possibility to hide results after voting. This is a new option in the Poll Modal.

<img width="621" alt="image" src="https://user-images.githubusercontent.com/26146736/199039544-7bba66b0-e5dc-4f79-8f70-4fc409f7bc88.png">

After you select this new option (Show result when poll is finished), the votes will only render after the poll is done with voting.

It stays like this after the user press "Vote" button.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/26146736/199039765-e68297a6-a3e0-48a1-b7f2-c5f98e5fb965.png">

After finishing the poll, all votes render at the end:

<img width="496" alt="image" src="https://user-images.githubusercontent.com/26146736/199039871-70392014-6214-4f3e-8d2f-99a1292e005a.png">


